### PR TITLE
Fix swagger routes by spelling progress correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
+- Fix spelling error in swagger docs
+
 ### 1.1.2
+
 - Update swagger docs to dereference for better AWS Support
 - [#11] Update `README.md` content
   - Update patch/minor version of dependencies.

--- a/routes/status.js
+++ b/routes/status.js
@@ -186,7 +186,7 @@ module.exports = function (app) {
 
   /**
   * @swagger
-  * /progess/{pkg}/{env}:
+  * /progress/{pkg}/{env}:
   *   get:
   *     summary: Gets the progress for a given package, environment
   *     security:
@@ -215,7 +215,7 @@ module.exports = function (app) {
   *               $ref: '#/definitions/Progress'
   *       404:
   *         description: Not found
-  * /progess/{pkg}/{env}/{version}:
+  * /progress/{pkg}/{env}/{version}:
   *   get:
   *     summary: Gets the progress for a given package, environment and version
   *     security:

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -9,6 +9,6 @@ describe('Swagger docs', function () {
     assume(docs.openapi).equal('3.0.2');
     assume(docs.paths).not.is.falsey();
     assume(docs.definitions.StatusEvent).not.is.falsey();
-    assume(docs.paths['/progess/{pkg}/{env}/{version}'].get.responses['200'].description).to.equal('OK');
+    assume(docs.paths['/progress/{pkg}/{env}/{version}'].get.responses['200'].description).to.equal('OK');
   });
 });


### PR DESCRIPTION
## Summary

`progress` was misspelled as `progess` in the swagger docs

## Changelog

- Fix spelling error in swagger docs

## Test Plan

N/A
